### PR TITLE
Fix issue #27: Refactored date_to_weeks using ChatGPT's recommendation.

### DIFF
--- a/ChatGPT/Task_2/2.3/kevin_barrios_task_2.3.py
+++ b/ChatGPT/Task_2/2.3/kevin_barrios_task_2.3.py
@@ -1,0 +1,185 @@
+import os
+import csv
+
+import matplotlib.pyplot as plt
+import matplotlib.lines as mlines
+
+from ast import literal_eval
+from datetime import datetime
+# Read the data into a list using literal_eval
+# Returns a list of filenames along with a list of those files' commits
+
+def get_list_from_csv(filename: str) -> list:
+
+    output = []
+
+    with open(filename) as csvfile:
+        reader = csv.DictReader(csvfile)
+
+        for row in reader:
+            try:
+                output.append([row["Filename"], literal_eval(row["Touches"])])
+            except:
+                print("Error when parsing filename " + row["Filename"])
+    
+    return output
+
+# Give each author their own color
+# Returns author colors, author commit counter, and total author counter
+
+def get_author_data(commitData: list):
+
+    authorColors = dict()
+
+    colorItems = [
+        "aqua", "darkcyan", "indigo", "blue", "blueviolet",
+        "brown", "coral", "crimson", "gray", "darkgreen",
+        "darkorange", "gold", "lightpink", "lime", "olive",
+        "lightslategray", "lightsteelblue", "peru", "royalblue", "pink",
+        "tan", "teal", "tomato", "violet", "yellow",
+        "darkorchid", "darkred", "darksalmon", "deeppink", "darkslateblue",
+        "goldenrod", "khaki", "lightseagreen", "mediumblue", "mediumaquamarine",
+        "mediumseagreen", "mediumslateblue", "mediumvioletred", "midnightblue", "navajowhite",
+        "olivedrab", "orangered", "orchid", "purple", "saddlebrown",
+        "salmon", "sienna", "seagreen", "skyblue", "silver"
+    ]
+
+    # Counts the total amount of authors
+    authorCounter = 0
+
+    # Counts how many commits each author makes
+    authorCommitCounter = dict()
+
+    for row in commitData:
+        for individualCommit in row[1]:
+            # Increment author commit counter
+            authorCommitCounter[individualCommit[0]] = authorCommitCounter.get(individualCommit[0], 0) + 1
+
+            # Give the author a color if they don't have a color
+            if individualCommit[0] not in authorColors:
+                if authorCounter >= len(colorItems):
+                    authorColors[individualCommit[0]] = "black"
+                    print(individualCommit[0], "was assigned 'black' by default. More colors are needed.")
+                else:
+                    authorColors[individualCommit[0]] = colorItems[authorCounter]
+
+                authorCounter += 1
+    
+    return authorColors, authorCommitCounter, authorCounter
+
+
+# Translate dates into weeks
+
+def date_to_weeks(date_str: str, base_year: int = 1950) -> float:
+	try:
+		# Parse the input date using `datetime.strptime`
+		date = datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%SZ')
+
+		# Define a reference date starting at January 1st of `base_year`
+		base_date = datetime(base_year, 1, 1)
+
+		# Calculate the difference in days between the given date and the base date
+		delta = (date - base_date).days
+
+		# Convert days to weeks
+		return delta / 7
+	except ValueError:
+		# Return -1 if there is an error with parsing the date
+		return -1
+
+
+# Get the earliest week to subtract from other dates
+
+def get_earliest_week(commitData: list) -> float:
+
+    earliestWeek = date_to_weeks(commitData[len(commitData) - 1][1][0][1]) # Initialize the earliest week with the first found date
+
+    for file in commitData:
+        for commit in file[1]:
+            thisWeek = date_to_weeks(commit[1])
+
+            if thisWeek < earliestWeek:
+                earliestWeek = thisWeek
+    
+    return earliestWeek
+
+
+# Takes a dict of authors and their commit counter
+# Returns an ordered list of those authors with more commits
+# occurring earlier in the list
+
+
+def get_author_commit_counter_list(authorCommitCounter: dict) -> list:
+
+    authorCommitCounterList = [*authorCommitCounter.items()]
+
+    # Bubble sort to organize authors based on commit amount
+
+    swap = True
+
+    while(swap):
+        swap = False
+        for index in range(0, len(authorCommitCounterList) - 2):
+            if authorCommitCounterList[index][1] < authorCommitCounterList[index + 1][1]:
+                temp = authorCommitCounterList[index]
+                authorCommitCounterList[index] = authorCommitCounterList[index + 1]
+                authorCommitCounterList[index + 1] = temp
+                swap = True
+    
+    return authorCommitCounterList
+
+
+# Main block where driving code is
+
+
+if __name__ == "__main__":
+
+    dataFile = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data", "authorsFileTouches_file_rootbeer.csv")
+
+    commitData = get_list_from_csv(dataFile)
+
+    authorColors, authorCommitCounter, authorCounter = get_author_data(commitData)
+
+    earliestWeek = get_earliest_week(commitData)
+
+    authorCommitCounterList = get_author_commit_counter_list(authorCommitCounter)
+        
+    x = []
+    y = []
+    colors = []
+ 
+    # Translates the data into three lists to plot on a scatterplot
+    for index, file in enumerate(commitData):
+        for commit in file[1]:
+            
+            # Adds the file index to the x list
+            x.append(index)
+
+            # Adds the date difference to the y list
+            y.append(date_to_weeks(commit[1]) - earliestWeek)
+
+            # Adds the color to the c list
+            colors.append(authorColors[commit[0]])
+
+    fig, ax = plt.subplots()
+
+    scatter = plt.scatter(x, y, c=colors, s=25)
+
+    plt.xlabel("File")
+    plt.ylabel("Week")
+
+    # Make the legend
+
+    markers = []
+
+    for author in authorCommitCounterList:
+        markers.append(mlines.Line2D([], [], color=authorColors[author[0]], marker='o', markersize=10, linestyle="None", label=f"{author[0]} ({authorCommitCounter[author[0]]})"))
+
+    legend = ax.legend(handles=markers, bbox_to_anchor=(1, 1), fontsize=9)
+
+    ax.add_artist(legend)
+
+    # Save the scatterplot as "Commits.png", then show it
+
+    plt.savefig("Commits", bbox_extra_artists=(legend,), bbox_inches="tight")
+    plt.show()


### PR DESCRIPTION
This pull request address issue https://github.com/Group3-472/Main/issues/27 in which I talked about how the date_to_weeks function may be too complex. Here I attempt to simplify this function by using python's datetime library in order to make the parsing of a date simpler and making the conversion more clear. A base year parameter was also added in case the function wanted to calculate weeks since a specific year.
(This is the same PR I previously submitted but updated to fit the new ChatGPT folder convention.)
- Kevin Barrios
- ChatGPT Lab
- https://chatgpt.com/share/6700b4c5-5a58-8013-aebe-f5d7f7cd4361

Summary After Review:
The overall improvements made to this file were improving the date_to_weeks function to make it more readable and easy to understand. Given the conversation Aarush and I, with additional insight from ChatGPT, we can conclude that the improvements made do not make the code worse in terms of time complexity and the function is now easier to comprehend.
ChatGPT Conversations Links:
https://chatgpt.com/share/6700b4c5-5a58-8013-aebe-f5d7f7cd4361
https://chatgpt.com/share/6701dc16-6bf0-8011-8a71-6840a8268c22
